### PR TITLE
Use rethrow to preserve useful backtraces

### DIFF
--- a/src/Roots.jl
+++ b/src/Roots.jl
@@ -94,7 +94,7 @@ function fzero{T <: Real}(f::Function, x0::Real, bracket::Vector{T}; kwargs...)
         if isa(ex, StateConverged) 
             return(ex.x0)
         else
-            throw(ex)
+            rethrow(ex)
         end
     end
 end

--- a/src/SOLVE.jl
+++ b/src/SOLVE.jl
@@ -52,10 +52,10 @@ function SOLVE(f::Function, x0::Real; ftol::Real=eps(zero(0.0))^(1/5), maxeval::
             if abs(f(guess)) < ftol
                 return guess
             else
-                throw(ex)
+                rethrow(ex)
             end
         else
-            throw(ex)
+            rethrow(ex)
         end
     end
     error("huh? Shouldn't get here")

--- a/src/derivative_free.jl
+++ b/src/derivative_free.jl
@@ -340,7 +340,7 @@ function derivative_free(f::Function, x0::Real;
         if isa(e, StateConverged)
             e.x0
         else
-            throw(e)
+            rethrow(e)
         end
     end
 end

--- a/src/fzero.jl
+++ b/src/fzero.jl
@@ -165,7 +165,7 @@ function a42(f::Function, a, b;
         if isa(ex, StateConverged)
             return ex.x0
         else
-            throw(ex)
+            rethrow(ex)
         end
     end
     error("root not found within max_iter iterations")

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -52,7 +52,7 @@ function secant_method(f::Function, x0::Real, x1::Real;
         if isa(e, StateConverged)
             e.x0
         else
-            throw(e)
+            rethrow(e)
         end
     end
 end


### PR DESCRIPTION
Using throw resets exception backtraces, making them less useful.